### PR TITLE
fixes after the rewrite of symmetry.jl

### DIFF
--- a/src/CondensedMatterSOS.jl
+++ b/src/CondensedMatterSOS.jl
@@ -41,6 +41,8 @@ include("monom-set.jl")
 include("ising.jl")
 
 include("symmetry.jl")
+export Lattice1Group
+
 include("action.jl")
 include("sos.jl")
 

--- a/src/action.jl
+++ b/src/action.jl
@@ -12,7 +12,7 @@ function Symmetry.SymbolicWedderburn.action(a::Action, el::DirectSum, mono::Cond
         rel_id = var.id - a.σ[1][1].id
         rel_index = var.index + 1
         @assert a.σ[rel_index][rel_id + 1] == var
-        id = ((rel_id + el.c.id) % el.c.n) + a.σ[1][1].id
+        id = ((rel_id + el.h.id) % el.h.n) + a.σ[1][1].id
         index = (rel_index^el.k.p) - 1
         new_var = CondensedMatterSOS.SpinVariable(id, index)
         if el.k.k.id != 0 && el.k.k.id != index + 1

--- a/src/action.jl
+++ b/src/action.jl
@@ -1,3 +1,4 @@
+import SumOfSquares.Symmetry
 export Action
 
 struct Action <: Symmetry.OnMonomials

--- a/src/symmetry.jl
+++ b/src/symmetry.jl
@@ -1,4 +1,3 @@
-using SumOfSquares
 import Random
 using GroupsCore
 
@@ -7,8 +6,6 @@ function __symmetric_grp_gens(n::Integer)
     return (Perm(UInt16[2, 1], false), Perm(UInt16[2:n; 1], false))
 end
 symmetric_group(n::Integer) = PermGroup(__symmetric_grp_gens(n)...)
-
-export Lattice1Group
 
 ## Klein C₂⊕C₂ group
 struct KleinGroup <: Group end

--- a/src/symmetry.jl
+++ b/src/symmetry.jl
@@ -130,12 +130,11 @@ function Base.rand(rng::Random.AbstractRNG, ::Random.SamplerTrivial{KleinPermGro
 end
 
 function Base.deepcopy_internal(g::KleinPermElement, dict::IdDict)
-    p = if haskey(dict, objectid(g.p))
-        dict[objectid(g.p)]
-    else
-        Base.deepcopy_internal(g.p, dict)
-    end
-    return KleinPermElement(p, g.k)
+    haskey(dict, g) && return dict[g]
+
+    h = KleinPermElement(Base.deepcopy_internal(g.p, dict), g.k)
+    dict[g] = h
+    return h
 end
 
 # CyclicGroup
@@ -233,22 +232,24 @@ function Base.rand(rng::Random.AbstractRNG, st::Random.SamplerTrivial{<:DirectSu
 end
 
 function Base.deepcopy_internal(g::DirectSumElem, dict::IdDict)
+    haskey(dict, g) && return g
     h = if isbits(g.h)
         g.h
-    elseif haskey(dict, objectid(g.h))
-        dict[objectid(g.h)]
+    elseif haskey(dict, g.h)
+        dict[g.h]
     else
         Base.deepcopy_internal(g.h, dict)
     end
-
     k = if isbits(g.k)
         g.k
-    elseif haskey(dict, objectid(g.k))
-        dict[objectid(g.k)]
+    elseif haskey(dict, g.k)
+        dict[g.k]
     else
         Base.deepcopy_internal(g.k, dict)
     end
-    return DirectSumElem(h, k)
+    new_g = DirectSumElem(h, k)
+    dict[g] = new_g
+    return new_g
 end
 
 # two aliases


### PR DESCRIPTION
;)

at least this time I get
```julia
ERROR: LoadError: MethodError: no method matching isless(::ComplexF64, ::ComplexF64)

Closest candidates are:
  isless(::Any, ::Missing)
   @ Base missing.jl:88
  isless(::Missing, ::Any)
   @ Base missing.jl:87

Stacktrace:
  [1] <(x::ComplexF64, y::ComplexF64)
    @ Base ./operators.jl:343
  [2] _permutation_quasi_upper_triangular(S::Matrix{ComplexF64})
    @ SumOfSquares.Certificate.Symmetry ~/.julia/packages/SumOfSquares/Sin7c/src/Certificate/Symmetry/block_diag.jl:43
  [3] orthogonal_transformation_to(A::Matrix{ComplexF64}, B::Matrix{ComplexF64})
    @ SumOfSquares.Certificate.Symmetry ~/.julia/packages/SumOfSquares/Sin7c/src/Certificate/Symmetry/block_diag.jl:110
  [4] ordered_block_diag(As::Vector{Matrix{ComplexF64}}, d::Int64)
    @ SumOfSquares.Certificate.Symmetry ~/.julia/packages/SumOfSquares/Sin7c/src/Certificate/Symmetry/block_diag.jl:144
  [5] (::SumOfSquares.Certificate.Symmetry.var"#15#17"{ComplexF64, SumOfSquares.Certificate.Symmetry.Pattern{Lattice1Group, Action}, MonomialBasis{CondensedMatterSOS.SpinMonomial, Vector{CondensedMatterSOS.SpinMonomial}}, SumOfSquares.Certificate.Symmetry._OrthogonalMatrix})(summand::SymbolicWedderburn.DirectSummand{ComplexF64, SparseArrays.SparseMatrixCSC{ComplexF64, Int64}})
    @ SumOfSquares.Certificate.Symmetry ~/.julia/packages/SumOfSquares/Sin7c/src/Certificate/Symmetry/wedderburn.jl:187
  [6] iterate
    @ ./generator.jl:47 [inlined]
  [7] collect_to!(dest::Vector{Vector{FixedPolynomialBasis{MultivariatePolynomials.VectorPolynomial{ComplexF64, MultivariatePolynomials.Term{ComplexF64, CondensedMatterSOS.SpinMonomial}}, Vector{MultivariatePolynomials.VectorPolynomial{ComplexF64, MultivariatePolynomials.Term{ComplexF64, CondensedMatterSOS.SpinMonomial}}}}}}, itr::Base.Generator{Vector{SymbolicWedderburn.DirectSummand{ComplexF64, SparseArrays.SparseMatrixCSC{ComplexF64, Int64}}}, SumOfSquares.Certificate.Symmetry.var"#15#17"{ComplexF64, SumOfSquares.Certificate.Symmetry.Pattern{Lattice1Group, Action}, MonomialBasis{CondensedMatterSOS.SpinMonomial, Vector{CondensedMatterSOS.SpinMonomial}}, SumOfSquares.Certificate.Symmetry._OrthogonalMatrix}}, offs::Int64, st::Int64)
    @ Base ./array.jl:840
  [8] collect_to_with_first!(dest::Vector{Vector{FixedPolynomialBasis{MultivariatePolynomials.VectorPolynomial{ComplexF64, MultivariatePolynomials.Term{ComplexF64, CondensedMatterSOS.SpinMonomial}}, Vector{MultivariatePolynomials.VectorPolynomial{ComplexF64, MultivariatePolynomials.Term{ComplexF64, CondensedMatterSOS.SpinMonomial}}}}}}, v1::Vector{FixedPolynomialBasis{MultivariatePolynomials.VectorPolynomial{ComplexF64, MultivariatePolynomials.Term{ComplexF64, CondensedMatterSOS.SpinMonomial}}, Vector{MultivariatePolynomials.VectorPolynomial{ComplexF64, MultivariatePolynomials.Term{ComplexF64, CondensedMatterSOS.SpinMonomial}}}}}, itr::Base.Generator{Vector{SymbolicWedderburn.DirectSummand{ComplexF64, SparseArrays.SparseMatrixCSC{ComplexF64, Int64}}}, SumOfSquares.Certificate.Symmetry.var"#15#17"{ComplexF64, SumOfSquares.Certificate.Symmetry.Pattern{Lattice1Group, Action}, MonomialBasis{CondensedMatterSOS.SpinMonomial, Vector{CondensedMatterSOS.SpinMonomial}}, SumOfSquares.Certificate.Symmetry._OrthogonalMatrix}}, st::Int64)
    @ Base ./array.jl:818
  [9] _collect(c::Vector{SymbolicWedderburn.DirectSummand{ComplexF64, SparseArrays.SparseMatrixCSC{ComplexF64, Int64}}}, itr::Base.Generator{Vector{SymbolicWedderburn.DirectSummand{ComplexF64, SparseArrays.SparseMatrixCSC{ComplexF64, Int64}}}, SumOfSquares.Certificate.Symmetry.var"#15#17"{ComplexF64, SumOfSquares.Certificate.Symmetry.Pattern{Lattice1Group, Action}, MonomialBasis{CondensedMatterSOS.SpinMonomial, Vector{CondensedMatterSOS.SpinMonomial}}, SumOfSquares.Certificate.Symmetry._OrthogonalMatrix}}, #unused#::Base.EltypeUnknown, isz::Base.HasShape{1})
    @ Base ./array.jl:812
 [10] collect_similar(cont::Vector{SymbolicWedderburn.DirectSummand{ComplexF64, SparseArrays.SparseMatrixCSC{ComplexF64, Int64}}}, itr::Base.Generator{Vector{SymbolicWedderburn.DirectSummand{ComplexF64, SparseArrays.SparseMatrixCSC{ComplexF64, Int64}}}, SumOfSquares.Certificate.Symmetry.var"#15#17"{ComplexF64, SumOfSquares.Certificate.Symmetry.Pattern{Lattice1Group, Action}, MonomialBasis{CondensedMatterSOS.SpinMonomial, Vector{CondensedMatterSOS.SpinMonomial}}, SumOfSquares.Certificate.Symmetry._OrthogonalMatrix}})
    @ Base ./array.jl:711
 [11] map(f::Function, A::Vector{SymbolicWedderburn.DirectSummand{ComplexF64, SparseArrays.SparseMatrixCSC{ComplexF64, Int64}}})
    @ Base ./abstractarray.jl:3263
 [12] _gram_basis(pattern::SumOfSquares.Certificate.Symmetry.Pattern{Lattice1Group, Action}, basis::MonomialBasis{CondensedMatterSOS.SpinMonomial, Vector{CondensedMatterSOS.SpinMonomial}}, #unused#::Type{ComplexF64})
    @ SumOfSquares.Certificate.Symmetry ~/.julia/packages/SumOfSquares/Sin7c/src/Certificate/Symmetry/wedderburn.jl:151
 [13] gram_basis
    @ ~/.julia/packages/SumOfSquares/Sin7c/src/Certificate/Symmetry/wedderburn.jl:126 [inlined]
 [14] bridge_constraint(#unused#::Type{SumOfSquares.Bridges.Constraint.SOSPolynomialBridge{ComplexF64, MathOptInterface.VectorAffineFunction{ComplexF64}, FullSpace, Union{MathOptInterface.ConstraintIndex{MathOptInterface.VectorOfVariables, MathOptInterface.HermitianPositiveSemidefiniteConeTriangle}, Vector{MathOptInterface.ConstraintIndex{MathOptInterface.VectorOfVariables, MathOptInterface.HermitianPositiveSemidefiniteConeTriangle}}}, MathOptInterface.HermitianPositiveSemidefiniteConeTriangle, MathOptInterface.HermitianPositiveSemidefiniteConeTriangle, Vector{Vector{FixedPolynomialBasis}}, MonomialBasis, SumOfSquares.Certificate.Symmetry.Ideal{SumOfSquares.Certificate.FixedBasis{NonnegPolyInnerCone{MathOptInterface.HermitianPositiveSemidefiniteConeTriangle}, MonomialBasis{CondensedMatterSOS.SpinMonomial, Vector{CondensedMatterSOS.SpinMonomial}}}, Lattice1Group, Action}, CondensedMatterSOS.SpinMonomial, Vector{CondensedMatterSOS.SpinMonomial}}}, model::MathOptInterface.Bridges.LazyBridgeOptimizer{MathOptInterface.Utilities.CachingOptimizer{Clarabel.MOImodule.Optimizer{Float64}, MathOptInterface.Utilities.UniversalFallback{MathOptInterface.Utilities.Model{Float64}}}}, f::MathOptInterface.VectorAffineFunction{ComplexF64}, s::SumOfSquares.SOSPolynomialSet{FullSpace, CondensedMatterSOS.SpinMonomial, Vector{CondensedMatterSOS.SpinMonomial}, SumOfSquares.Certificate.Symmetry.Ideal{SumOfSquares.Certificate.FixedBasis{NonnegPolyInnerCone{MathOptInterface.HermitianPositiveSemidefiniteConeTriangle}, MonomialBasis{CondensedMatterSOS.SpinMonomial, Vector{CondensedMatterSOS.SpinMonomial}}}, Lattice1Group, Action}})
    @ SumOfSquares.Bridges.Constraint ~/.julia/packages/SumOfSquares/Sin7c/src/Bridges/Constraint/sos_polynomial.jl:54
 [15] add_bridged_constraint(b::MathOptInterface.Bridges.LazyBridgeOptimizer{MathOptInterface.Utilities.CachingOptimizer{Clarabel.MOImodule.Optimizer{Float64}, MathOptInterface.Utilities.UniversalFallback{MathOptInterface.Utilities.Model{Float64}}}}, BridgeType::Type, f::MathOptInterface.VectorAffineFunction{ComplexF64}, s::SumOfSquares.SOSPolynomialSet{FullSpace, CondensedMatterSOS.SpinMonomial, Vector{CondensedMatterSOS.SpinMonomial}, SumOfSquares.Certificate.Symmetry.Ideal{SumOfSquares.Certificate.FixedBasis{NonnegPolyInnerCone{MathOptInterface.HermitianPositiveSemidefiniteConeTriangle}, MonomialBasis{CondensedMatterSOS.SpinMonomial, Vector{CondensedMatterSOS.SpinMonomial}}}, Lattice1Group, Action}})
    @ MathOptInterface.Bridges ~/.julia/packages/MathOptInterface/LQvlf/src/Bridges/bridge_optimizer.jl:1673
 [16] add_constraint(b::MathOptInterface.Bridges.LazyBridgeOptimizer{MathOptInterface.Utilities.CachingOptimizer{Clarabel.MOImodule.Optimizer{Float64}, MathOptInterface.Utilities.UniversalFallback{MathOptInterface.Utilities.Model{Float64}}}}, f::MathOptInterface.VectorAffineFunction{ComplexF64}, s::SumOfSquares.SOSPolynomialSet{FullSpace, CondensedMatterSOS.SpinMonomial, Vector{CondensedMatterSOS.SpinMonomial}, SumOfSquares.Certificate.Symmetry.Ideal{SumOfSquares.Certificate.FixedBasis{NonnegPolyInnerCone{MathOptInterface.HermitianPositiveSemidefiniteConeTriangle}, MonomialBasis{CondensedMatterSOS.SpinMonomial, Vector{CondensedMatterSOS.SpinMonomial}}}, Lattice1Group, Action}})
    @ MathOptInterface.Bridges ~/.julia/packages/MathOptInterface/LQvlf/src/Bridges/bridge_optimizer.jl:1748
 [17] _copy_constraints(dest::MathOptInterface.Bridges.LazyBridgeOptimizer{MathOptInterface.Utilities.CachingOptimizer{Clarabel.MOImodule.Optimizer{Float64}, MathOptInterface.Utilities.UniversalFallback{MathOptInterface.Utilities.Model{Float64}}}}, src::MathOptInterface.Utilities.UniversalFallback{MathOptInterface.Utilities.Model{Float64}}, index_map::MathOptInterface.Utilities.IndexMap, index_map_FS::MathOptInterface.Utilities.DoubleDicts.IndexDoubleDictInner{MathOptInterface.VectorAffineFunction{ComplexF64}, SumOfSquares.SOSPolynomialSet{FullSpace, CondensedMatterSOS.SpinMonomial, Vector{CondensedMatterSOS.SpinMonomial}, SumOfSquares.Certificate.Symmetry.Ideal{SumOfSquares.Certificate.FixedBasis{NonnegPolyInnerCone{MathOptInterface.HermitianPositiveSemidefiniteConeTriangle}, MonomialBasis{CondensedMatterSOS.SpinMonomial, Vector{CondensedMatterSOS.SpinMonomial}}}, Lattice1Group, Action}}}, cis_src::Vector{MathOptInterface.ConstraintIndex{MathOptInterface.VectorAffineFunction{ComplexF64}, SumOfSquares.SOSPolynomialSet{FullSpace, CondensedMatterSOS.SpinMonomial, Vector{CondensedMatterSOS.SpinMonomial}, SumOfSquares.Certificate.Symmetry.Ideal{SumOfSquares.Certificate.FixedBasis{NonnegPolyInnerCone{MathOptInterface.HermitianPositiveSemidefiniteConeTriangle}, MonomialBasis{CondensedMatterSOS.SpinMonomial, Vector{CondensedMatterSOS.SpinMonomial}}}, Lattice1Group, Action}}}})
    @ MathOptInterface.Utilities ~/.julia/packages/MathOptInterface/LQvlf/src/Utilities/copy.jl:261
 [18] _copy_constraints(dest::MathOptInterface.Bridges.LazyBridgeOptimizer{MathOptInterface.Utilities.CachingOptimizer{Clarabel.MOImodule.Optimizer{Float64}, MathOptInterface.Utilities.UniversalFallback{MathOptInterface.Utilities.Model{Float64}}}}, src::MathOptInterface.Utilities.UniversalFallback{MathOptInterface.Utilities.Model{Float64}}, index_map::MathOptInterface.Utilities.IndexMap, cis_src::Vector{MathOptInterface.ConstraintIndex{MathOptInterface.VectorAffineFunction{ComplexF64}, SumOfSquares.SOSPolynomialSet{FullSpace, CondensedMatterSOS.SpinMonomial, Vector{CondensedMatterSOS.SpinMonomial}, SumOfSquares.Certificate.Symmetry.Ideal{SumOfSquares.Certificate.FixedBasis{NonnegPolyInnerCone{MathOptInterface.HermitianPositiveSemidefiniteConeTriangle}, MonomialBasis{CondensedMatterSOS.SpinMonomial, Vector{CondensedMatterSOS.SpinMonomial}}}, Lattice1Group, Action}}}})
    @ MathOptInterface.Utilities ~/.julia/packages/MathOptInterface/LQvlf/src/Utilities/copy.jl:273
 [19] pass_nonvariable_constraints_fallback(dest::MathOptInterface.Bridges.LazyBridgeOptimizer{MathOptInterface.Utilities.CachingOptimizer{Clarabel.MOImodule.Optimizer{Float64}, MathOptInterface.Utilities.UniversalFallback{MathOptInterface.Utilities.Model{Float64}}}}, src::MathOptInterface.Utilities.UniversalFallback{MathOptInterface.Utilities.Model{Float64}}, index_map::MathOptInterface.Utilities.IndexMap, constraint_types::Vector{Any})
    @ MathOptInterface.Utilities ~/.julia/packages/MathOptInterface/LQvlf/src/Utilities/copy.jl:284
 [20] pass_nonvariable_constraints(dest::MathOptInterface.Bridges.LazyBridgeOptimizer{MathOptInterface.Utilities.CachingOptimizer{Clarabel.MOImodule.Optimizer{Float64}, MathOptInterface.Utilities.UniversalFallback{MathOptInterface.Utilities.Model{Float64}}}}, src::MathOptInterface.Utilities.UniversalFallback{MathOptInterface.Utilities.Model{Float64}}, idxmap::MathOptInterface.Utilities.IndexMap, constraint_types::Vector{Any})
    @ MathOptInterface.Bridges ~/.julia/packages/MathOptInterface/LQvlf/src/Bridges/bridge_optimizer.jl:441
 [21] _pass_constraints(dest::MathOptInterface.Bridges.LazyBridgeOptimizer{MathOptInterface.Utilities.CachingOptimizer{Clarabel.MOImodule.Optimizer{Float64}, MathOptInterface.Utilities.UniversalFallback{MathOptInterface.Utilities.Model{Float64}}}}, src::MathOptInterface.Utilities.UniversalFallback{MathOptInterface.Utilities.Model{Float64}}, index_map::MathOptInterface.Utilities.IndexMap, variable_constraints_not_added::Vector{Any})
    @ MathOptInterface.Utilities ~/.julia/packages/MathOptInterface/LQvlf/src/Utilities/copy.jl:332
 [22] default_copy_to(dest::MathOptInterface.Bridges.LazyBridgeOptimizer{MathOptInterface.Utilities.CachingOptimizer{Clarabel.MOImodule.Optimizer{Float64}, MathOptInterface.Utilities.UniversalFallback{MathOptInterface.Utilities.Model{Float64}}}}, src::MathOptInterface.Utilities.UniversalFallback{MathOptInterface.Utilities.Model{Float64}})
    @ MathOptInterface.Utilities ~/.julia/packages/MathOptInterface/LQvlf/src/Utilities/copy.jl:507
 [23] copy_to
    @ ~/.julia/packages/MathOptInterface/LQvlf/src/Bridges/bridge_optimizer.jl:451 [inlined]
 [24] optimize!
    @ ~/.julia/packages/MathOptInterface/LQvlf/src/MathOptInterface.jl:84 [inlined]
 [25] optimize!(m::MathOptInterface.Utilities.CachingOptimizer{MathOptInterface.Bridges.LazyBridgeOptimizer{MathOptInterface.Utilities.CachingOptimizer{Clarabel.MOImodule.Optimizer{Float64}, MathOptInterface.Utilities.UniversalFallback{MathOptInterface.Utilities.Model{Float64}}}}, MathOptInterface.Utilities.UniversalFallback{MathOptInterface.Utilities.Model{Float64}}})
    @ MathOptInterface.Utilities ~/.julia/packages/MathOptInterface/LQvlf/src/Utilities/cachingoptimizer.jl:316
 [26] optimize!(model::Model; ignore_optimize_hook::Bool, _differentiation_backend::MathOptInterface.Nonlinear.SparseReverseMode, kwargs::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
    @ JuMP ~/.julia/packages/JuMP/mvUVO/src/optimizer_interface.jl:439
 [27] optimize!
    @ ~/.julia/packages/JuMP/mvUVO/src/optimizer_interface.jl:409 [inlined]
 [28] energy(H::MultivariatePolynomials.VectorPolynomial{Complex{Int64}, MultivariatePolynomials.Term{Complex{Int64}, CondensedMatterSOS.SpinMonomial}}, maxdegree::Int64, solver::Type; cone::NonnegPolyInnerCone{MathOptInterface.HermitianPositiveSemidefiniteConeTriangle}, sparsity::SumOfSquares.Certificate.Sparsity.Monomial{ClusterCompletion}, non_sparse::SumOfSquares.Certificate.MaxDegree{NonnegPolyInnerCone{MathOptInterface.HermitianPositiveSemidefiniteConeTriangle}, MonomialBasis}, certificate::SumOfSquares.Certificate.Symmetry.Ideal{SumOfSquares.Certificate.FixedBasis{NonnegPolyInnerCone{MathOptInterface.HermitianPositiveSemidefiniteConeTriangle}, MonomialBasis{CondensedMatterSOS.SpinMonomial, Vector{CondensedMatterSOS.SpinMonomial}}}, Lattice1Group, Action}, kws::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
    @ CondensedMatterSOS ~/.julia/dev/CondensedMatterSOS/src/sos.jl:37
 [29] energy
    @ ~/.julia/dev/CondensedMatterSOS/src/sos.jl:24 [inlined]
 [30] #hamiltonian_energy#3
    @ ~/.julia/dev/CondensedMatterSOS/examples/Benchmark_1.jl:36 [inlined]
 [31] macro expansion
    @ ./timing.jl:273 [inlined]
 [32] f(L::Int64, d::Int64, consecutive::Bool; symmetry::Bool)
    @ Main ~/.julia/dev/CondensedMatterSOS/examples/Benchmark_1.jl:109
 [33] f(L::Int64, d::Int64, consecutive::Bool)
    @ Main ~/.julia/dev/CondensedMatterSOS/examples/Benchmark_1.jl:105
 [34] top-level scope
    @ ~/.julia/dev/CondensedMatterSOS/examples/Benchmark_1.jl:128
 [35] include(fname::String)
    @ Base.MainInclude ./client.jl:478
 [36] top-level scope
    @ REPL[3]:1
in expression starting at /home/kalmar/.julia/dev/CondensedMatterSOS/examples/Benchmark_1.jl:128

```
@blegat ball is in your court ;)
